### PR TITLE
Updates to clock subtraction and failed 4th down (and misc stuff)

### DIFF
--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -365,8 +365,15 @@ public class Game implements Serializable {
         else possStr = awayTeam.abbr;
         String yardsNeedAdj = "" + gameYardsNeed;
         if (gameYardLine + gameYardsNeed >= 100) yardsNeedAdj = "Goal";
+        int gameDownAdj;
+        if (gameDown > 4) {
+            gameDownAdj = 4;
+        } else
+        {
+            gameDownAdj = gameDown;
+        }
         return "\n\n" + homeTeam.abbr + " " + homeScore + " - " + awayScore + " " + awayTeam.abbr + ", Time: " + convGameTime() +
-                "\n\t" + possStr + " " + gameDown + " and " + yardsNeedAdj + " at " + gameYardLine + " yard line." + "\n";
+                "\n\t" + possStr + " " + gameDownAdj + " and " + yardsNeedAdj + " at " + gameYardLine + " yard line." + "\n";
     }
 
     /**
@@ -549,8 +556,17 @@ public class Game implements Serializable {
      */
     private void runPlay( Team offense, Team defense ) {
         if ( gameDown > 4 ) {
+            // DELETE ME: Add a log to the game log to see if I did this right
+            gameEventLog += getEventPrefix() + "TURNOVER ON DOWNS!\n" + offense.abbr + " failed to convert on " + (gameDown - 1) + "th down. " + defense.abbr + " takes over possession on downs.";
+
+            //Turn over on downs, change possession, set to first down and 10 yards to go
             gamePoss = !gamePoss;
             gameDown = 1;
+            gameYardsNeed = 10;
+            //and flip which direction the ball is moving in
+            gameYardLine = 100 - gameYardLine;
+
+            gameEventLog += getEventPrefix() + "Takeover on downs\n" + defense.abbr + " gets the ball with " + gameDown + "st down after " + offense.abbr + " failed on 4th down.";
         }
         double preferPass = (offense.getPassProf()*2 - defense.getPassDef()) * Math.random() - 10;
         double preferRush = (offense.getRushProf()*2 - defense.getRushDef()) * Math.random() + offense.teamStratOff.getRYB();
@@ -666,6 +682,11 @@ public class Game implements Serializable {
                 gameDown++;
                 selWRStats[4]++;
                 selWR.statsDrops++;
+                passAttempt(offense, selWR, selWRStats, yardsGain);
+                //Drop ball = inc pass, so run time for the play, stop clock until next play, move on (aka return;)
+                gameTime -= 15*Math.random();
+                return;
+
             } else {
                 //no drop
                 yardsGain = (int) (( normalize(offense.getQB(0).ratPassPow) + normalize(selWR.ratRecSpd) - normalize(selCB.ratCBSpd) )*Math.random()/3.7
@@ -678,7 +699,7 @@ public class Game implements Serializable {
                 }
                 if ( escapeChance > 75 && Math.random() < (0.1 + (offense.teamStratOff.getPAB()-defense.teamStratDef.getPAB())/200)) {
                     //wr escapes for TD
-                    yardsGain += 100;
+                    yardsGain += 100 - gameYardLine;
                 }
 
                 //add yardage
@@ -713,7 +734,11 @@ public class Game implements Serializable {
 
         } else {
             //no completion, advance downs
+            passAttempt(offense, selWR, selWRStats, yardsGain);
             gameDown++;
+            //Incomplete pass stops the clock, so just run time for how long the play took, then move on
+            gameTime -= 15*Math.random();
+            return;
         }
 
         passAttempt(offense, selWR, selWRStats, yardsGain);
@@ -732,11 +757,15 @@ public class Game implements Serializable {
             }
             gamePoss = !gamePoss;
             gameYardLine = 100 - gameYardLine;
+            gameTime -= 15*Math.random();
+            return;
         }
 
         if ( gotTD ) {
+            gameTime -= 15*Math.random();
             kickXP( offense, defense );
             kickOff( offense );
+            return;
         }
 
         gameTime -= 15 + 15*Math.random();
@@ -1057,7 +1086,7 @@ public class Game implements Serializable {
         offense.getQB(0).statsSacked++;
         gameYardsNeed += 3;
         gameYardLine -= 3;
-        gameDown++;
+
         if ( gamePoss ) { // home possession
             HomeQBStats[5]++;
         } else {
@@ -1066,8 +1095,14 @@ public class Game implements Serializable {
 
         if (gameYardLine < 0) {
             // Safety!
+            // Eat some time up for the play that was run, stop it once play is over
+            gameTime -= 10*Math.random();
             safety();
         }
+
+
+        //Similar amount of time as rushing, minus some in-play time -- sacks are faster (usually)
+        gameTime -= 25 + 10*Math.random();
     }
 
     /**

--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -556,8 +556,8 @@ public class Game implements Serializable {
      */
     private void runPlay( Team offense, Team defense ) {
         if ( gameDown > 4 ) {
-            // DELETE ME: Add a log to the game log to see if I did this right
-            gameEventLog += getEventPrefix() + "TURNOVER ON DOWNS!\n" + offense.abbr + " failed to convert on " + (gameDown - 1) + "th down. " + defense.abbr + " takes over possession on downs.";
+            // DELETE ME: Add a log to the game log to see if turnover on downs happens right
+            //gameEventLog += getEventPrefix() + "TURNOVER ON DOWNS!\n" + offense.abbr + " failed to convert on " + (gameDown - 1) + "th down. " + defense.abbr + " takes over possession on downs.";
 
             //Turn over on downs, change possession, set to first down and 10 yards to go
             gamePoss = !gamePoss;
@@ -566,7 +566,6 @@ public class Game implements Serializable {
             //and flip which direction the ball is moving in
             gameYardLine = 100 - gameYardLine;
 
-            gameEventLog += getEventPrefix() + "Takeover on downs\n" + defense.abbr + " gets the ball with " + gameDown + "st down after " + offense.abbr + " failed on 4th down.";
         }
         double preferPass = (offense.getPassProf()*2 - defense.getPassDef()) * Math.random() - 10;
         double preferRush = (offense.getRushProf()*2 - defense.getRushDef()) * Math.random() + offense.teamStratOff.getRYB();


### PR DESCRIPTION
Basic idea of what I was going for:

In the current code, the clock runs the same for each passing play, whether that play was a sack for yardage loss (the clocks runs), a sack for a safety (clock stops for freekick), an incompletion (drop or bad throw) (clock stops after the play is dead), a catch for a TD (clock stops for the XP try) or a catch (which so far we're assuming is always in bounds, so the clock runs). 

I wanted to suggest a change to allow the clock to run differently depending on the outcome. In doing this, I noticed that when a play is run, "5th down is checked" (aka did you just fail a fourth down), and if you did, possession is changed and the down is set to 1. (glassesref joke goes here) However, the yards to go remained, and the yard line variable didn't change.

Because the game uses 100 yards, instead of the "your own 1-49, the 50, the opp 49-1" system, if USC stops ASU on the 40 yard line in the game, they would then take over --on their own 40--. The analogy to real life is if USC stopped ASU on 4th and 3 from the ASU 40 yard line, USC would get the ball with 1st and 3 to go, on the USC 40 yard line.

I updated the code to set the yards to go to 10 so that the defense that just got the 4th down stop gives their offense the ball with 1st and 10 to go instead of 1st and whatever-the-other-team-had-left. I also set gameYardLine = 100 - gameYardLine to reflect the fact that the ball is now moving in the other direction, and counting up to 100. (I flat out stole this from getFumble).

--------------

List of changes:

Updated getEventPrefix to use "gameDownAdj" in the return string instead of "gameDown". This allows for us to print out that a team failed a 4th down try, and not have the game log read "5 and 3" in the event a team turns over on 4th down.

Tested that turnover on downs worked properly by having a log added that reported the 4th down failure and the subsequent 1st down take over by the other team. (If I can figure out how to attach a screenshot I'll show the result). I got rid of the 1st down take over but thought you might like a 4th down failure message log, so I left it in but commented.
Updated turnover on downs logic to reset to 1st and 10 for the new team and flip the direction the ball is moving (put them on the right yardline)

Changed a dropped ball to take up less time (because the ball was dropped and now the clock shouldn't run after the play), update passattempt, and then exit (return;) and move on.

If the WR escapes for a TD (vs just having his play be long enough for a TD), previously he got a flat 100 yard gain. Updated the code to give him the rest of the yardage that was left in the drive instead of the flat 100.

If a pass is incomplete (WR didn't drop it, but didn't catch it either), the clock decrements the time of the play, runs passAttempts, then exits.

If the pass is caught, but then fumbled, or run all the way for a TD, the clock loses the time that would burn off during the play, and then stops for either the change of possession or the XP and kickoff (and on kickoff, more time is decremented as part of the kickoff ...function? method? whatever the vocabulary is)

Previously, if the QB was sacked, no time ran off the clock (because the play simply ran qbSack(offense) and then exited, and qbSack didn't subtract any time). Updated qbSack to take up some time and stop the clock if the result was a safety (clock stops for change of possession) and take  the equivalent of a rushing play if the sack is just a regular sack (because at that point it -is- a rushing), minus 5 static seconds because it's a short rushing play.

--------------

Finally, if the play is a catch but not a TD or a fumble, then the clock decrements as it previously did on every passing play that didn't exit early (sack or interception).