### PR TITLE
Update KickXP logic to not try PAT if Walk-off TD

### DIFF
--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -1053,7 +1053,7 @@ public class Game implements Serializable {
      */
     private void kickXP( Team offense, Team defense ) {
         // No XP/2pt try if the TD puts the bottom OT offense ahead (aka wins the game)
-        if (playingOT && bottomOT && (((numOT % 2 == 0) && awayScore > homeScore) || ((numOT % 2 != 0) && homeScore > awayScore))
+        if (playingOT && bottomOT && (((numOT % 2 == 0) && awayScore > homeScore) || ((numOT % 2 != 0) && homeScore > awayScore)))
         {
             gameEventLog += getEventPrefix() + " " + tdInfo + "\n" + offense.abbr + " wins on a walk-off touchdown!";
         }

--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -952,6 +952,7 @@ public class Game implements Serializable {
         rushAttempt(offense, defense, selRB, RB1pref, RB2pref, yardsGain);
 
         if ( gotTD ) {
+            gameTime -= 5 + 15*Math.random(); // Clock stops for the TD, just burn time for the play
             kickXP( offense, defense );
             if (!playingOT) kickOff( offense );
             else resetForOT();
@@ -1051,6 +1052,16 @@ public class Game implements Serializable {
      * @param defense defending the point after
      */
     private void kickXP( Team offense, Team defense ) {
+        // No XP/2pt try if the TD puts the bottom OT offense ahead (aka wins the game)
+        if (playingOT && bottomOT && (((numOT % 2 == 0) && awayScore > homeScore) || ((numOT % 2 != 0) && homeScore > awayScore))
+        {
+            gameEventLog += getEventPrefix() + " " + tdInfo + "\n" + offense.abbr + " wins on a walk-off touchdown!";
+        }
+        else if (!playingOT && gameTime <= 0 && ((homeScore - awayScore > 2) || (awayScore - homeScore > 2))) {
+            if (Math.abs(homeScore - awayScore) < 7) gameEventLog += getEventPrefix() + " " + tdInfo + "\n" + offense.abbr + " wins on a walk-off touchdown!";
+            else gameEventLog += getEventPrefix() + " " + tdInfo;
+        }
+        else {
         if ( (numOT >= 3) || (((gamePoss && (awayScore - homeScore) == 2) || (!gamePoss && (homeScore - awayScore) == 2)) && gameTime < 300 )) {
             //go for 2
             boolean successConversion = false;
@@ -1115,7 +1126,7 @@ public class Game implements Serializable {
             offense.getK(0).statsXPAtt++;
         }
     }
-
+}
     /**
      * Kick the ball off, turning the ball over to the other team.
      * @param offense kicking the ball off

--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -1057,8 +1057,11 @@ public class Game implements Serializable {
         {
             gameEventLog += getEventPrefix() + " " + tdInfo + "\n" + offense.abbr + " wins on a walk-off touchdown!";
         }
+        // If a TD is scored as time expires, there is no XP/2pt if the score difference is greater than 2
         else if (!playingOT && gameTime <= 0 && ((homeScore - awayScore > 2) || (awayScore - homeScore > 2))) {
+            //Walkoff TD!
             if (Math.abs(homeScore - awayScore) < 7) gameEventLog += getEventPrefix() + " " + tdInfo + "\n" + offense.abbr + " wins on a walk-off touchdown!";
+            //Just rubbing in the win
             else gameEventLog += getEventPrefix() + " " + tdInfo;
         }
         else {

--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -633,7 +633,7 @@ public class Game implements Serializable {
 
             // If it's 1st and Goal to go, adjust yards needed to reflect distance for a TD so that play selection reflects actual yards to go
             // If we don't do this, gameYardsNeed may be higher than the actualy distance for a TD and suboptimal plays may be chosen
-            if (gameDown == 1 && gameYardLine >= 91) gameYardsNeed = 100 - gameYardLine
+            if (gameDown == 1 && gameYardLine >= 91) gameYardsNeed = 100 - gameYardLine;
 
             if ( gameTime <= 30 && !playingOT ) {
                 if ( ((gamePoss && (awayScore - homeScore) <= 3) || (!gamePoss && (homeScore - awayScore) <= 3)) && gameYardLine > 60 ) {

--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -1060,8 +1060,8 @@ public class Game implements Serializable {
         // If a TD is scored as time expires, there is no XP/2pt if the score difference is greater than 2
         else if (!playingOT && gameTime <= 0 && ((homeScore - awayScore > 2) || (awayScore - homeScore > 2))) {
             //Walkoff TD!
-            if (Math.abs(homeScore - awayScore) < 7) gameEventLog += getEventPrefix() + " " + tdInfo + "\n" + offense.abbr + " wins on a walk-off touchdown!";
-            //Just rubbing in the win
+            if ((Math.abs(homeScore - awayScore) < 7) && ((gamePoss && offense == homeTeam) || (!gamePoss && offense == awayTeam))) gameEventLog += getEventPrefix() + " " + tdInfo + "\n" + offense.abbr + " wins on a walk-off touchdown!";
+            //Just rubbing in the win or saving some pride
             else gameEventLog += getEventPrefix() + " " + tdInfo;
         }
         else {


### PR DESCRIPTION
If a team scores a go ahead TD in the bottom frame of an overtime, or if a team scores a walk-off TD as time expires (the six points gives them a lead of more than 2), KickXP just adds to the game log as if it was any other TD, and notes that the score was a walk-off winner.

Also updated rushingPlay() to decrement time if a TD is scored (previously no time came off the clock)