### PR TITLE
Fixed Walkoff Logic to Behave Properly

### DIFF
--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -1060,7 +1060,7 @@ public class Game implements Serializable {
         // If a TD is scored as time expires, there is no XP/2pt if the score difference is greater than 2
         else if (!playingOT && gameTime <= 0 && ((homeScore - awayScore > 2) || (awayScore - homeScore > 2))) {
             //Walkoff TD!
-            if ((Math.abs(homeScore - awayScore) < 7) && ((gamePoss && offense == homeTeam) || (!gamePoss && offense == awayTeam))) gameEventLog += getEventPrefix() + " " + tdInfo + "\n" + offense.abbr + " wins on a walk-off touchdown!";
+            if ((Math.abs(homeScore - awayScore) < 7) && ((gamePoss && homeScore > awayScore) || (!gamePoss && awayScore > homeScore))) gameEventLog += getEventPrefix() + " " + tdInfo + "\n" + offense.abbr + " wins on a walk-off touchdown!";
             //Just rubbing in the win or saving some pride
             else gameEventLog += getEventPrefix() + " " + tdInfo;
         }


### PR DESCRIPTION
This is why you don't code at 2 in the morning.

The old logic was:

(Math.abs(homeScore - awayScore) < 7) && ((gamePoss && offense == homeTeam) || (!gamePoss && offense == awayTeam))

Is the score difference less than 7 and then for some reason...does the homeTeam have the ball and were they passed in as offense or vice versa for the awayTeam. I have no idea what I was trying to do there because I'm checking the same thing twice. Anyway, I thought of a scenario that breaks this:

Home team is losing 20 to 29. Scores a TD as time expires. Score is now 26 to 29 (difference<7) and homeTeam is on offense. This fulfills the conditions and would print that they just won on a walkoff, when in reality they just saved some face.

So I just removed redundant possession check and added in a check to make sure that the team that just scored has the lead.