### PR TITLE
Update kickoff/freekick to return if gametime <= 0

### DIFF
--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -1135,6 +1135,8 @@ public class Game implements Serializable {
      * @param offense kicking the ball off
      */
     private void kickOff( Team offense ) {
+        if (gameTime <= 0) return;
+        else {
         //Decide whether to onside kick. Only if losing but within 8 points with < 3 min to go
         if ( gameTime < 180 && ((gamePoss && (awayScore - homeScore) <= 8 && (awayScore - homeScore) > 0)
                 || (!gamePoss && (homeScore - awayScore) <=8 && (homeScore - awayScore) > 0))) {
@@ -1163,13 +1165,15 @@ public class Game implements Serializable {
 
         gameTime -= 15*Math.random();
     }
-
+}
     /**
      * Kick the ball off following a safety, turning the ball over to the other team.
      * Safety free kicks happen from the 20 instead of the 35, so start the kicker from further back.
      * @param offense kicking the ball off
      */
     private void freeKick( Team offense ) {
+        if (gameTime <= 0) return;
+        else {
         //Decide whether to onside kick. Only if losing but within 8 points with < 3 min to go
         if ( gameTime < 180 && ((gamePoss && (awayScore - homeScore) <= 8 && (awayScore - homeScore) > 0)
                 || (!gamePoss && (homeScore - awayScore) <=8 && (homeScore - awayScore) > 0))) {
@@ -1198,9 +1202,10 @@ public class Game implements Serializable {
             gameYardsNeed = 10;
             gamePoss = !gamePoss;
             gameTime -= 15*Math.random();
+        
+            }
         }
     }
-
 
     /**
      * Punt the ball if it is a 4th down and decided not to go for it.
@@ -1449,5 +1454,4 @@ public class Game implements Serializable {
     private int normalize(int rating) {
         return (100 + rating)/2;
     }
-
 }


### PR DESCRIPTION
Onside kicks were happening if a trailing team scored a meaningless TD as time expired. It didn't change the outcome because kicks can't be returned, but it would still log onside kick tries that technically shouldn't happen.

![image](https://cloud.githubusercontent.com/assets/11052658/14062491/22c8c0e8-f35e-11e5-91b2-9a49d76c4638.png)
