### PR TITLE
Updated runPlay() end of game logic

### DIFF
--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -635,7 +635,7 @@ public class Game implements Serializable {
             // If we don't do this, gameYardsNeed may be higher than the actualy distance for a TD and suboptimal plays may be chosen
             if (gameDown == 1 && gameYardLine >= 91) gameYardsNeed = 100 - gameYardLine;
 
-            if ( gameTime <= 30 && !playingOT ) {
+            if ( gameTime <= 30 && !playingOT && ((gamePoss && (awayScore > homeScore)) || (!gamePoss && (homeScore > awayScore)))) {
                 if ( ((gamePoss && (awayScore - homeScore) <= 3) || (!gamePoss && (homeScore - awayScore) <= 3)) && gameYardLine > 60 ) {
                     //last second FGA
                     fieldGoalAtt( offense, defense );


### PR DESCRIPTION
Updated runPlay() to choose plays the way it should when the clock is under 30 seconds; previously if a team was losing by less than 3 (or winning) it was forced into a passing play until it scored or turned the ball over on downs.

Added a check to make sure that the team with the ball is losing to the initial if statement.