### PR TITLE
Update/Fix End of Game Play Selection

### DIFF
--- a/app/src/main/java/CFBsimPack/Game.java
+++ b/app/src/main/java/CFBsimPack/Game.java
@@ -635,7 +635,9 @@ public class Game implements Serializable {
             // If we don't do this, gameYardsNeed may be higher than the actualy distance for a TD and suboptimal plays may be chosen
             if (gameDown == 1 && gameYardLine >= 91) gameYardsNeed = 100 - gameYardLine;
 
-            if ( gameTime <= 30 && !playingOT && ((gamePoss && (awayScore > homeScore)) || (!gamePoss && (homeScore > awayScore)))) {
+            //Under 30 seconds to play, check that the team with the ball is trailing or tied, do something based on the score difference
+            if ( gameTime <= 30 && !playingOT && ((gamePoss && (awayScore >= homeScore)) || (!gamePoss && (homeScore >= awayScore)))) {
+                //Down by 3 or less, or tied, and you have the ball
                 if ( ((gamePoss && (awayScore - homeScore) <= 3) || (!gamePoss && (homeScore - awayScore) <= 3)) && gameYardLine > 60 ) {
                     //last second FGA
                     fieldGoalAtt( offense, defense );


### PR DESCRIPTION
When I implemented the fix to teams always passing it with under 30 to play, I only checked if the team was trailing or ahead, not if they were tied.

As a result, a team within field goal range that has the ball and is tied will pass the ball rather than kick the potential game winning FG.

So I changed > to >= and added some comments to describe the scenario we're checking.