### PR TITLE
	Adding Story About TV Network Deal for Conf or Team

### DIFF
--- a/app/src/main/java/CFBsimPack/League.java
+++ b/app/src/main/java/CFBsimPack/League.java
@@ -427,6 +427,90 @@ public class League {
                         newsStories.get(0).add("Success in the Classroom Spilling Onto the Field>" + saveBless.name + " find themselves in an unusual, but agreeable, position. The university, which has been slowly increasing admissions standards and taking strives to improve it's academic offerings, has begun to find itself counted among the Top 100 schools nationwide. As a result, the football Program program is finding itself with a new breed of recruit: smarter, more driven, and more capable of learning complex schemes. " + saveBless.name + " also finds itself with increased overall attention, as its name is beginning to have association with some of the most academically rigorous institutions in the country. As the school's mission to improve its academic standing continues, it stands to reason that it will enjoy an increased level of prestige.");
                         break;
 
+                    case 7:
+                        //TV Deal -- Each conf will have it's own network name and a story about a network getting a TV deal can't be posted more than once (same for individual tv deals)
+                        //If the conference doesn't get a TV deal, saveBless will get an individual deal which alters the story if/when the conference gets their own network
+
+                        String networkName; // Name of conf TV network
+
+                        switch(getConfNumber(saveBless.conference)){ //Set name using switch method fed by conference's number
+                            case 0:
+                                networkName = "SOUTH Sportsnet";
+                                break;
+                            case 1:
+                                networkName = "LAKES Vision";
+                                break;
+                            case 2:
+                                networkName = "The NORTH Network";
+                                break;
+                            case 3:
+                                networkName = "COWBY Championship Channel";
+                                break;
+                            case 4:
+                                networkName = "PACIF Pics";
+                                break;
+                            case 5:
+                                networkName = "MOUNT Mega Sports";
+                                break;
+                            default:
+                                networkName = "Collegiate Sports Network";
+                                break;
+                        }
+
+                        //Setup variables to check for individual Team TV deals
+                        int teamTVDeals = 0;
+                        ArrayList<String> tvDealTeams = new ArrayList<String>();
+
+                        for (int ttv = 0; i < conferences.get(getConfNumber(saveBless.conference)).confTeams.size(); ttv++){ //Check each team in the conference
+                            if(conferences.get(getConfNumber(saveBless.conference)).confTeams.get(ttv).teamTVDeal){ //To see if they have an individual deal
+                                teamTVDeals++; //If they do, increment teamTVDeals
+                                tvDealTeams.add(conferences.get(getConfNumber(saveBless.conference)).confTeams.get(ttv).name); //and add their name to the list of teams with a deal
+                            }
+                        }
+
+                        //Lets write some news -- Start by checking if the conf has a deal, if every team has their own deal, and a 20% chance
+                        if(Math.random() <= 0.20 && !findTeamAbbr(saveBless.abbr).confTVDeal && teamTVDeals == 0){ //If no teams have individual deals and the conference has no network, 20% a conference network is formed
+                            //Conference TV Deal -- Plus 5 prestige to the conference's member schools
+                            newsStories.get(0).add(saveBless.conference + " Announces Launch of New TV Network>In a joint press conference between conference officials and all member schools, The " + saveBless.conference + " Conference announced the launch of it's new TV network " + networkName + ". The network, which was largely spearheaded by member school " + saveBless.name + " is expected to increase the revenue and recruiting range of member schools in ways previously unseen by the conference. The channel goes live next week with the first broadcast expected to be the morning matchup between " + saveBless.gameSchedule.get(0).homeTeam.name + " and " + saveBless.gameSchedule.get(0).awayTeam.name + ".");
+
+                            //Add prestige and set confTVDeal to true for each team so that the next time this comes around, a duplicate story won't be posted about a network being formed (and prestige is only granted once)
+                           for(int ctv = 0; ctv < conferences.get(getConfNumber(saveBless.conference)).confTeams.size(); ctv++){
+                               conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).confTVDeal = true;
+                               conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).teamPrestige += 5;
+                           }
+                        }
+
+                        //Now check to see if it failed because a Team TV Deal Exists
+                        else if(Math.random() <= 0.20 && !findTeamAbbr(saveBless.abbr).confTVDeal && teamTVDeals != 0){
+                            //Conference TV Deal -- But there had to be negotiations with the teams that already had TV deals -- Plus prestige to the conference members
+                            //Teams that already have individual deals don't get the bonus prestige (or maybe get less) cause they were already on TV
+                            newsStories.get(0).add("FILL ME IN WITH A STORY ABOUT THE BIRTH OF A CONFERENCE NETWORK BUT THERE WERE NEGOTIATIONS WITH TEAMS THAT HAD INDIVIDUAL DEALS");
+
+                            //Add prestige and set confTVDeal to true for each team so that the next time this comes around, a duplicate story won't be posted about a network being formed (and prestige is only granted once)
+                            for(int ctv = 0; ctv < conferences.get(getConfNumber(saveBless.conference)).confTeams.size(); ctv++) {
+                                conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).confTVDeal = true;
+                                if(tvDealTeams.contains(conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).name)){
+                                    conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).teamPrestige += 1; // Your TV already exists, so this whole conference TV network is whatever to you
+                                }
+                                else {
+                                    conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).teamPrestige += 5; // Welcome to the Small Screen, bay bee!
+                                }
+                            }
+
+                        }
+
+                        //Check now to see if it was the 20% chance that failed
+                        else if(!findTeamAbbr(saveBless.abbr).confTVDeal && !findTeamAbbr(saveBless.abbr).teamTVDeal){ //If no conf tv deal and no team tv deal -- Congrats the saveBless.name Sports Network is born!
+                            newsStories.get(0).add("FILL ME IN WITH A STORY ABOUT THE BIRTH OF A TEAM NETWORK");
+                            findTeamAbbr(saveBless.abbr).teamTVDeal = true;
+                        }
+
+                        else { //There's a Conf TV deal, or a Team TV deal, or both, and the chance to form the Conf network failed, so, pull another story
+                            i--;
+                            break;
+                        }
+                        break;
+
 
                     default:
                         i--;
@@ -486,7 +570,7 @@ public class League {
                         break;
 
                     case 3:
-                        //Hazing rituals by upper-classmen reported by under-classmen and scared off recruits -- Curse Developing #1
+                        //Hazing rituals by upperclassmen reported by underclassmen and scared off recruits -- Curse Developing #1
 
                         //Figure out if the recruit scared off was a RS (if the cursed team is rivals with the user team) or a FR
                         String starRSOrFR;
@@ -1911,7 +1995,7 @@ public class League {
                     (t.totalWins - t.wins) + "," + (t.totalLosses - t.losses) + "," + t.totalCCs + "," + t.totalNCs + "," + t.rivalTeam + "," +
                     t.totalNCLosses + "," + t.totalCCLosses + "," + t.totalBowls + "," + t.totalBowlLosses + "," +
                     t.teamStratOffNum + "," + t.teamStratDefNum + "," + (t.showPopups ? 1 : 0) + "," +
-                    t.winStreak.getStreakCSV() + "%" + t.evenYearHomeOpp + "%\n");
+                    t.winStreak.getStreakCSV() + t.teamTVDeal + "," + t.confTVDeal + "%" + t.evenYearHomeOpp + "%\n");
             sb.append(t.getPlayerInfoSaveFile());
             sb.append("END_PLAYERS\n");
         }

--- a/app/src/main/java/CFBsimPack/League.java
+++ b/app/src/main/java/CFBsimPack/League.java
@@ -360,7 +360,7 @@ public class League {
                 String storyPlayer;
 
                 for(int i = 0; i < 1; i++){
-                switch((int)(Math.random() * 7)) { //Change the number Math.random is multiplied by to the number of cases (so last case # + 1)
+                switch((int)(Math.random() * 8)) { //Change the number Math.random is multiplied by to the number of cases (so last case # + 1)
                     case 0:
                         //Hired a shiny new coach who used to play for the school (feed those Vol fans wishing for Peyton something to dream on)
                         newsStories.get(0).add("Blue Chip hire for Bad Break University>" + saveBless.name + " announced the hire of alumnus and former professional coach " + getRandName() + ", today. It was long rumored that the highly touted coach considered the position a \"dream job\", but talks between the two didn't heat up until this offseason. The hire certainly helps boost the prestige of the University's football program, which has fallen on hard times as of late.");
@@ -453,7 +453,7 @@ public class League {
                                 networkName = "MOUNT Mega Sports";
                                 break;
                             default:
-                                networkName = "Collegiate Sports Network";
+                                networkName = (saveBless.conference + " Collegiate Sports Network");
                                 break;
                         }
 
@@ -461,17 +461,44 @@ public class League {
                         int teamTVDeals = 0;
                         ArrayList<String> tvDealTeams = new ArrayList<String>();
 
-                        for (int ttv = 0; i < conferences.get(getConfNumber(saveBless.conference)).confTeams.size(); ttv++){ //Check each team in the conference
+                        String memberSchoolsWithTV;
+
+                        for (int ttv = 0; ttv < conferences.get(getConfNumber(saveBless.conference)).confTeams.size(); ttv++){ //Check each team in the conference
                             if(conferences.get(getConfNumber(saveBless.conference)).confTeams.get(ttv).teamTVDeal){ //To see if they have an individual deal
                                 teamTVDeals++; //If they do, increment teamTVDeals
                                 tvDealTeams.add(conferences.get(getConfNumber(saveBless.conference)).confTeams.get(ttv).name); //and add their name to the list of teams with a deal
                             }
                         }
 
-                        //Lets write some news -- Start by checking if the conf has a deal, if every team has their own deal, and a 20% chance
-                        if(Math.random() <= 0.20 && !findTeamAbbr(saveBless.abbr).confTVDeal && teamTVDeals == 0){ //If no teams have individual deals and the conference has no network, 20% a conference network is formed
+                        if (tvDealTeams.size() == 1){ //Set up string for story about teams with individual deals being negotiated with
+                            memberSchoolsWithTV = "member school " + tvDealTeams.get(0);
+                        }
+                        else{
+                            memberSchoolsWithTV = "member schools ";
+                            for(int tdt = 0; tdt < tvDealTeams.size(); tdt++){
+                                if(tdt == tvDealTeams.size()-1) { //If the last team in the list
+                                    memberSchoolsWithTV += " and ";
+                                }
+                                if (tvDealTeams.size() == 2){ //If just two teams, no need for a comma (SchoolX and SchoolY)
+                                    memberSchoolsWithTV += (tvDealTeams.get(tdt) + " ");
+                                }
+                                else{ //Need commas
+                                    if(tdt == tvDealTeams.size()-1){//Last team in the list, no need for a comma (, and SchoolZ)
+                                        memberSchoolsWithTV += (tvDealTeams.get(tdt) + " ");
+                                    }
+                                    else{ //A team at the start or middle of a list 3 or larger (School W, SchoolX, SchoolY, and)
+                                        //WE OXFORD COMMA NOW
+                                        memberSchoolsWithTV += (tvDealTeams.get(tdt) + ", ");
+                                    }
+                                }
+                            }
+                        }
+
+
+                        //Lets write some news -- Start by checking if the conf has a deal, if every team does not have their own deal, and a 20% chance
+                        if(Math.random() <= 0 && !findTeamAbbr(saveBless.abbr).confTVDeal && teamTVDeals == 0){ //If no teams have individual deals and the conference has no network, 20% a conference network is formed
                             //Conference TV Deal -- Plus 5 prestige to the conference's member schools
-                            newsStories.get(0).add(saveBless.conference + " Announces Launch of New TV Network>In a joint press conference between conference officials and all member schools, The " + saveBless.conference + " Conference announced the launch of it's new TV network " + networkName + ". The network, which was largely spearheaded by member school " + saveBless.name + " is expected to increase the revenue and recruiting range of member schools in ways previously unseen by the conference. The channel goes live next week with the first broadcast expected to be the morning matchup between " + saveBless.gameSchedule.get(0).homeTeam.name + " and " + saveBless.gameSchedule.get(0).awayTeam.name + ".");
+                            newsStories.get(0).add(saveBless.conference + " Announces Launch of New TV Network>In a joint press conference between conference officials and all member schools, The " + saveBless.conference + " Conference announced the launch of it's new TV network " + networkName + ". The network, which was largely spearheaded by member school " + saveBless.name + ", is expected to increase the revenue and recruiting range of member schools in ways previously unseen by the conference. The channel goes live next week with the first broadcast expected to be the morning matchup between " + saveBless.gameSchedule.get(0).homeTeam.name + " and " + saveBless.gameSchedule.get(0).awayTeam.name + ".");
 
                             //Add prestige and set confTVDeal to true for each team so that the next time this comes around, a duplicate story won't be posted about a network being formed (and prestige is only granted once)
                            for(int ctv = 0; ctv < conferences.get(getConfNumber(saveBless.conference)).confTeams.size(); ctv++){
@@ -480,17 +507,20 @@ public class League {
                            }
                         }
 
-                        //Now check to see if it failed because a Team TV Deal Exists
-                        else if(Math.random() <= 0.20 && !findTeamAbbr(saveBless.abbr).confTVDeal && teamTVDeals != 0){
+                        //We didn't use the above story, so check to see if it failed because a Team TV Deal Exists
+                        else if(Math.random() <= 0.20 && !findTeamAbbr(saveBless.abbr).confTVDeal && teamTVDeals != 0){ //If 20% chance, no conf tv deal, but someone in the conf has an individual deal
+
                             //Conference TV Deal -- But there had to be negotiations with the teams that already had TV deals -- Plus prestige to the conference members
                             //Teams that already have individual deals don't get the bonus prestige (or maybe get less) cause they were already on TV
-                            newsStories.get(0).add("FILL ME IN WITH A STORY ABOUT THE BIRTH OF A CONFERENCE NETWORK BUT THERE WERE NEGOTIATIONS WITH TEAMS THAT HAD INDIVIDUAL DEALS");
+                            newsStories.get(0).add(saveBless.conference + " Announces New Network After Lengthy Negotiations>After negotiations that went long into the night, The " + saveBless.conference + " Conference released a statement today detailing the launch of " + networkName + ", the conference's first exclusive TV network. Sources familiar with the situation explained that the agreement was delayed by negotiations with " + memberSchoolsWithTV + " who had previously inked TV deals of their own for team specific networks. Specific details were not released, but Conference Comissioner " + storyFullName + " did go on record as saying the only TV network for all conference teams will be " + networkName + " moving forward.");
 
                             //Add prestige and set confTVDeal to true for each team so that the next time this comes around, a duplicate story won't be posted about a network being formed (and prestige is only granted once)
                             for(int ctv = 0; ctv < conferences.get(getConfNumber(saveBless.conference)).confTeams.size(); ctv++) {
                                 conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).confTVDeal = true;
                                 if(tvDealTeams.contains(conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).name)){
-                                    conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).teamPrestige += 1; // Your TV already exists, so this whole conference TV network is whatever to you
+                                    //Give nothing to saveBless cause they already got a fat chunk of prestige
+                                    if(conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).name.equals(saveBless.name)) conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).teamPrestige += 0;
+                                    else conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).teamPrestige += 1; // Your TV network already existed, so this whole conference TV network is whatever to you
                                 }
                                 else {
                                     conferences.get(getConfNumber((saveBless.conference))).confTeams.get(ctv).teamPrestige += 5; // Welcome to the Small Screen, bay bee!
@@ -499,13 +529,25 @@ public class League {
 
                         }
 
-                        //Check now to see if it was the 20% chance that failed
-                        else if(!findTeamAbbr(saveBless.abbr).confTVDeal && !findTeamAbbr(saveBless.abbr).teamTVDeal){ //If no conf tv deal and no team tv deal -- Congrats the saveBless.name Sports Network is born!
-                            newsStories.get(0).add("FILL ME IN WITH A STORY ABOUT THE BIRTH OF A TEAM NETWORK");
-                            findTeamAbbr(saveBless.abbr).teamTVDeal = true;
+                        //We didn't use either of the above stories, so now see if it's just the 20% chance that failed
+                        else if(!findTeamAbbr(saveBless.abbr).confTVDeal && !findTeamAbbr(saveBless.abbr).teamTVDeal){ //If no conf tv deal and no team tv deal -- Congrats, the saveBless.name Sports Network is born!
+                            if(saveBless.abbr.equals("HOL") || saveBless.abbr.equals("ULA")){//Different story for LA or Hollywood cause...well they're LA and Hollywood and they're inking a TV deal
+                                String holOrUlaTVName; //Different channel names for different schools
+                                if(saveBless.abbr.equals("HOL")){ //Hollywood St. Sportsnet -- LA Fans know and loathe the inspiration for this one
+                                    holOrUlaTVName = "Hollywood St announced today, that it will launch it's own exclusive athletics channel 'Hollywood St. Sportsnet'.";
+                                }
+                                else{ // ULA All Access, cause it's alliterative and catchy
+                                    holOrUlaTVName = "The University of Los Angeles announced that 'ULA All Access', a channel dedicated exclusively to hosting ULA Athletics content, is set to begin broadcasting.";
+                                }
+                                newsStories.get(0).add(saveBless.name + " Takes Advantage of Non-Athletic Local Talents>In a move that left everyone around the country wondering \"what took so long?\", " + holOrUlaTVName + " The channel goes live next week, with the first broadcast expected to be " + findTeamAbbr(saveBless.abbr).gameSchedule.get(0).awayTeam.name + " at " + findTeamAbbr(saveBless.abbr).gameSchedule.get(0).homeTeam.name + ". " + saveBless.name + " cited the wealth of local talent and expertise in the broadcasting industry as major catalysts for getting the network off the ground and on the air.");
+                            }
+                            else {//Any other school
+                                newsStories.get(0).add(saveBless.name + " Does Its Best Hollywood St Impression>In a move that's expected to greatly boost the national awareness and recruiting reach of " + saveBless.name + ", the university announced that it's ready to go live with its first foray into national broadcasting in the form of a university specific athletics television network. The school has remained hush on many details surrounding the network, but the channel is expected to go live next week when a name and availability will be announced at the conclusion of the final fall practice of the year.");
+                                findTeamAbbr(saveBless.abbr).teamTVDeal = true;
+                            }
                         }
 
-                        else { //There's a Conf TV deal, or a Team TV deal, or both, and the chance to form the Conf network failed, so, pull another story
+                        else { //There's a Conf TV deal, or a Team TV deal, or both, or the chance to form the Conf network failed, so, pull another story
                             i--;
                             break;
                         }
@@ -1995,7 +2037,7 @@ public class League {
                     (t.totalWins - t.wins) + "," + (t.totalLosses - t.losses) + "," + t.totalCCs + "," + t.totalNCs + "," + t.rivalTeam + "," +
                     t.totalNCLosses + "," + t.totalCCLosses + "," + t.totalBowls + "," + t.totalBowlLosses + "," +
                     t.teamStratOffNum + "," + t.teamStratDefNum + "," + (t.showPopups ? 1 : 0) + "," +
-                    t.winStreak.getStreakCSV() + t.teamTVDeal + "," + t.confTVDeal + "%" + t.evenYearHomeOpp + "%\n");
+                    t.winStreak.getStreakCSV() + "," +  t.teamTVDeal + "," + t.confTVDeal + "%" + t.evenYearHomeOpp + "%\n");
             sb.append(t.getPlayerInfoSaveFile());
             sb.append("END_PLAYERS\n");
         }

--- a/app/src/main/java/CFBsimPack/Team.java
+++ b/app/src/main/java/CFBsimPack/Team.java
@@ -268,8 +268,6 @@ public class Team {
             totalCCs = Integer.parseInt(teamInfo[6]);
             totalNCs = Integer.parseInt(teamInfo[7]);
             rivalTeam = teamInfo[8];
-            teamTVDeal = Boolean.parseBoolean(teamInfo[20]);
-            confTVDeal = Boolean.parseBoolean(teamInfo[21]);
             if (teamInfo.length >= 13) {
                 totalNCLosses = Integer.parseInt(teamInfo[9]);
                 totalCCLosses = Integer.parseInt(teamInfo[10]);
@@ -284,6 +282,10 @@ public class Team {
                                 Integer.parseInt(teamInfo[19]),
                                 Integer.parseInt(teamInfo[16]),
                                 teamInfo[17]);
+                                if (teamInfo.length >= 22){
+                                    teamTVDeal = Boolean.parseBoolean(teamInfo[20]);
+                                    confTVDeal = Boolean.parseBoolean(teamInfo[21]);
+                                }
                     }
                 }
             } else {

--- a/app/src/main/java/CFBsimPack/Team.java
+++ b/app/src/main/java/CFBsimPack/Team.java
@@ -116,6 +116,9 @@ public class Team {
     public int teamStratOffNum;
     public int teamStratDefNum;
 
+    public boolean confTVDeal;
+    public boolean teamTVDeal;
+
     private static final int NFL_OVR = 90;
     private static final double NFL_CHANCE = 0.5;
 
@@ -265,6 +268,8 @@ public class Team {
             totalCCs = Integer.parseInt(teamInfo[6]);
             totalNCs = Integer.parseInt(teamInfo[7]);
             rivalTeam = teamInfo[8];
+            teamTVDeal = Boolean.parseBoolean(teamInfo[20]);
+            confTVDeal = Boolean.parseBoolean(teamInfo[21]);
             if (teamInfo.length >= 13) {
                 totalNCLosses = Integer.parseInt(teamInfo[9]);
                 totalCCLosses = Integer.parseInt(teamInfo[10]);


### PR DESCRIPTION
IMPORTANT: If this story triggers, there's a 20% chance that if it hasn't already, a conference will be granted a TV deal, which gives every team a prestige bonus. I set the bonus to be 5, unless they had already gotten a team TV deal, in which case the bonus is 1. saveBless gets no additional prestige. If the conference already has a TV Deal, this story is skipped and a different one is printed in week 0.

I'd like your feedback on that for balance purposes or if we should just remove the prestige bonus all together.

---

Mechanics: If this story is triggered, a switch statement is performed to figure out what the name of the conference tv network will be. The total number of individual team tv deals that have been reached (aka the number of times this story has triggered to run the generic individual team tv network (think Longhorn Network) for teams within the conference), and their names are added to a string array.

If there are no team deals, and no conf deal, there's a 20% chance the conf tv network is formed.

If there are team deals and no conf deal, there's a 20% chance the conf tv network is formed and the story printed references having to come to an agreement with the teams that already had their own channel.

If there is no team deal for saveBless and no conf deal, and the 20% chance fails, saveBless gets their own network (special stories exist for HOL and ULA cause that's Hollywood and LA and well...TV is what they do)

Otherwise, the for loop is tried again for a different story.