### PR TITLE
Fixed bug with developing stories

### DIFF
--- a/app/src/main/java/CFBsimPack/League.java
+++ b/app/src/main/java/CFBsimPack/League.java
@@ -875,7 +875,7 @@ public class League {
     
                         }
                     }
-                break;
+                break; // this break happens every week that isn't curseDevelopingWeek
 
 
                 default:

--- a/app/src/main/java/CFBsimPack/League.java
+++ b/app/src/main/java/CFBsimPack/League.java
@@ -816,55 +816,64 @@ public class League {
                             newsStories.get(curseDevelopingWeek+2).add("Punishment Announced for " + saveCurse.name + " Upperclassmen>In a statement released through its Athletics Department today, " +saveCurse.name+" Head Coach " + storyFullName + " announced that he had spoken with each member of the team privately and determined who the upperclassmen responsible for the over-the-top hazing occurring within the program were. Not wishing to draw further scrutiny to individual players, " +storyLastName+" stated that the group of players would be responsible for identifying the best way to give back to the local community and carrying out whatever volunteer work was necessary to see the project through to completion.");
                         }
                     }
+                break;
                 case 2: //QB and WR had a fight, how did the first game go? -- More scenarios to be added later
-                    PlayerQB cursedQB;
-                    PlayerWR cursedWR;
-                    PlayerWR cursedWR2;
-                    PlayerWR cursedWR3;
-
-                    if(saveCurse.gameSchedule.get(0).homeTeam == saveCurse){
-                        cursedQB = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).homeTeam.getQB(0);
-                        cursedWR = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).homeTeam.getWR(0);
-                        cursedWR2 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).homeTeam.getWR(1);
-                        cursedWR3 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).homeTeam.getWR(2);
-                    }
-                    else{
-                        cursedQB = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getQB(0);
-                        cursedWR = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getWR(0);
-                        cursedWR2 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getWR(1);
-                        cursedWR3 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getWR(2);
-                    }
-                    if (100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) > 60 && cursedWR.statsTargets > cursedWR2.statsTargets && cursedWR.statsTargets > cursedWR3.statsTargets) {
-                        if (findTeam((saveCurse.abbr)).wins == 0) {
-                            //QB and WR still in sync, but the team lost
-                            newsStories.get(curseDevelopingWeek + 1).add(saveCurse.name + " Locker Room Scuffle Affects Week 1 Performance>Despite managing to find their sync after a locker room altercation last week, quarterback " + cursedQB.name + " and wide receiver " + cursedWR.name + " still left a lasting negative impression in the minds and performance of their teammates. " + cursedQB.name + "'s " + cursedQB.statsPassYards + " yards and " + cursedWR.name + "'s " + cursedWR.statsReceptions + " receptions could not bring the rest of the team out of the funk that eventually saw them drop their season opener.");
-                        } else {
-                            //Hey, boys will be boys, right? Team won and QB/WR still hooked up for a good game
-                            newsStories.get(curseDevelopingWeek + 1).add("Water Under the Bridge at " + saveCurse.name + ">" + saveCurse.name + " didn't appear to remember the locker room altercation from last week nor the media attention it garnered as " + cursedQB.name + " threw for " + cursedQB.statsPassYards + " yards and " + cursedWR.name + " caught " + cursedWR.statsReceptions + " balls to help lift " + saveCurse.name + " in their season opener. " + cursedQB.name.replaceAll(".* ", "") + " still looked to his favorite target more than any other receiver, but all is still not perfectly well within the program.");
+                    if(curseDevelopingWeek == currentWeek){
+                        PlayerQB cursedQB;
+                        PlayerWR cursedWR;
+                        PlayerWR cursedWR2;
+                        PlayerWR cursedWR3;
+    
+                        if(saveCurse.gameSchedule.get(0).homeTeam == saveCurse){
+                            cursedQB = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).homeTeam.getQB(0);
+                            cursedWR = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).homeTeam.getWR(0);
+                            cursedWR2 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).homeTeam.getWR(1);
+                            cursedWR3 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).homeTeam.getWR(2);
                         }
-                    }
-                    else if(100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) > 59){
-                        //QB had a good game but didn't hit his old favorite more than other WRs
-                        newsStories.get(curseDevelopingWeek+1).add("Team Unrest Continues at " + saveCurse.name + ">Quarterback " + cursedQB.name + " looked good in his season opener, throwing " + cursedQB.statsPassComp + " completions for " + cursedQB.statsPassYards + " yards, primarily to receivers not named " + cursedWR.name + ". Sources within the program have remained quiet since last week's locker room scuffle between the once tight QB-WR duo, but one thing is clear: " + cursedQB.name.replaceAll(".* ","") + " has not forgotten.");
-                    }
-                    else if(100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) > 44 && 100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) < 60){
-                        //QB was pretty much a non-factor
-                        String winOrLoss;
-                        if(findTeam((saveCurse.abbr)).wins == 0) winOrLoss = "loss";
-                        else winOrLoss = "win";
-
-                        newsStories.get(curseDevelopingWeek+1).add(cursedQB.name + " a Non-Factor in Season Opener>On the heels of a locker room fight that dominated national media and brought the leadership capabilities of the " + saveCurse.name + " coaching staff into question, starting quarterback " + cursedQB.name + " opened his season without much fanfare. Or much of anything. " + cursedQB.name.replaceAll(".* ","") + " threw for " + cursedQB.statsPassYards + " yards on " + cursedQB.statsPassComp + " for " + cursedQB.statsPassAtt + " passing, managing to look perfectly average in a season opening " + winOrLoss + ".");
-                    }
-
-                    else{
-                        //QB had a bad game and the team lost
-                        if(findTeam((saveCurse.abbr)).wins == 0){
-                            newsStories.get(curseDevelopingWeek + 1).add(cursedQB.name + " Fails to Find Rhythm in Season Opener>Just over a week after reports surfaced of a locker room fight between " + saveCurse.name + " quarterback " + cursedQB.name + " and his favorite target, wide receiver " + cursedWR.name + ", the two are back in the media spotlight for a lackluster performance in a season opening loss. Looking visibly disoriented and confused at times, " + cursedQB.name.replaceAll(".* ", "") + " went just " + cursedQB.statsPassComp + " for " + cursedQB.statsPassAtt + " passing, and failed to achieve any consistency in a losing effort.");
+                        else{
+                            cursedQB = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getQB(0);
+                            cursedWR = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getWR(0);
+                            cursedWR2 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getWR(1);
+                            cursedWR3 = findTeamAbbr(saveCurse.abbr).gameSchedule.get(0).awayTeam.getWR(2);
                         }
-                        else{ //QB looked crappy but the team managed to pull one out anyway
-                            newsStories.get(curseDevelopingWeek+1).add(saveCurse.name + " Manage a Win Despite Poor QB Play>Appearing to still be caught up in the locker room drama of last week, " + cursedQB.name + " had to get by with a little help from his friends. Going " + cursedQB.statsPassComp + " for " + cursedQB.statsPassAtt + " while looking lost at times, " + cursedQB.name.replaceAll(".* ","") + "'s performance left a lot to be desired. Still, the damage done was not enough to surrender a loss, and " + saveCurse.name + " marches into Week 2 with a 1-0 record.");
+                        if (100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) > 60 && cursedWR.statsTargets > cursedWR2.statsTargets && cursedWR.statsTargets > cursedWR3.statsTargets) {
+                            if (findTeam((saveCurse.abbr)).wins == 0) {
+                                //QB and WR still in sync, but the team lost
+                                newsStories.get(curseDevelopingWeek + 1).add(saveCurse.name + " Locker Room Scuffle Affects Week 1 Performance>Despite managing to find their sync after a locker room altercation last week, quarterback " + cursedQB.name + " and wide receiver " + cursedWR.name + " still left a lasting negative impression in the minds and performance of their teammates. " + cursedQB.name + "'s " + cursedQB.statsPassYards + " yards and " + cursedWR.name + "'s " + cursedWR.statsReceptions + " receptions could not bring the rest of the team out of the funk that eventually saw them drop their season opener.");
+                                break;
+                            } else {
+                                //Hey, boys will be boys, right? Team won and QB/WR still hooked up for a good game
+                                newsStories.get(curseDevelopingWeek + 1).add("Water Under the Bridge at " + saveCurse.name + ">" + saveCurse.name + " didn't appear to remember the locker room altercation from last week nor the media attention it garnered as " + cursedQB.name + " threw for " + cursedQB.statsPassYards + " yards and " + cursedWR.name + " caught " + cursedWR.statsReceptions + " balls to help lift " + saveCurse.name + " in their season opener. " + cursedQB.name.replaceAll(".* ", "") + " still looked to his favorite target more than any other receiver, but all is still not perfectly well within the program.");
+                                break;
+                            }
                         }
-
+                        else if(100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) > 59){
+                            //QB had a good game but didn't hit his old favorite more than other WRs
+                            newsStories.get(curseDevelopingWeek+1).add("Team Unrest Continues at " + saveCurse.name + ">Quarterback " + cursedQB.name + " looked good in his season opener, throwing " + cursedQB.statsPassComp + " completions for " + cursedQB.statsPassYards + " yards, primarily to receivers not named " + cursedWR.name + ". Sources within the program have remained quiet since last week's locker room scuffle between the once tight QB-WR duo, but one thing is clear: " + cursedQB.name.replaceAll(".* ","") + " has not forgotten.");
+                            break;
+                        }
+                        else if(100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) > 44 && 100*cursedQB.statsPassComp/Math.max(1,cursedQB.statsPassAtt) < 60){
+                            //QB was pretty much a non-factor
+                            String winOrLoss;
+                            if(findTeam((saveCurse.abbr)).wins == 0) winOrLoss = "loss";
+                            else winOrLoss = "win";
+    
+                            newsStories.get(curseDevelopingWeek+1).add(cursedQB.name + " a Non-Factor in Season Opener>On the heels of a locker room fight that dominated national media and brought the leadership capabilities of the " + saveCurse.name + " coaching staff into question, starting quarterback " + cursedQB.name + " opened his season without much fanfare. Or much of anything. " + cursedQB.name.replaceAll(".* ","") + " threw for " + cursedQB.statsPassYards + " yards on " + cursedQB.statsPassComp + " for " + cursedQB.statsPassAtt + " passing, managing to look perfectly average in a season opening " + winOrLoss + ".");
+                            break;
+                        }
+    
+                        else{
+                            //QB had a bad game and the team lost
+                            if(findTeam((saveCurse.abbr)).wins == 0){
+                                newsStories.get(curseDevelopingWeek + 1).add(cursedQB.name + " Fails to Find Rhythm in Season Opener>Just over a week after reports surfaced of a locker room fight between " + saveCurse.name + " quarterback " + cursedQB.name + " and his favorite target, wide receiver " + cursedWR.name + ", the two are back in the media spotlight for a lackluster performance in a season opening loss. Looking visibly disoriented and confused at times, " + cursedQB.name.replaceAll(".* ", "") + " went just " + cursedQB.statsPassComp + " for " + cursedQB.statsPassAtt + " passing, and failed to achieve any consistency in a losing effort.");
+                                break;
+                            }
+                            else{ //QB looked crappy but the team managed to pull one out anyway
+                                newsStories.get(curseDevelopingWeek+1).add(saveCurse.name + " Manage a Win Despite Poor QB Play>Appearing to still be caught up in the locker room drama of last week, " + cursedQB.name + " had to get by with a little help from his friends. Going " + cursedQB.statsPassComp + " for " + cursedQB.statsPassAtt + " while looking lost at times, " + cursedQB.name.replaceAll(".* ","") + "'s performance left a lot to be desired. Still, the damage done was not enough to surrender a loss, and " + saveCurse.name + " marches into Week 2 with a 1-0 record.");
+                                break;
+                            }
+    
+                        }
                     }
                 break;
 


### PR DESCRIPTION
Fixed the issue where stories that develop off of preseason stories keep getting added to week 1 until the end of the season.

Also fixed a bug where the Hazing Scandal story would cause the locker room fight stories to be triggered.


PS: I have no idea what is going on with these github additions/deletions. I literally just added breaks and an if statement to case 2. No idea why there's a huge gap.